### PR TITLE
Fix header syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#html-table-of-contents
+# html-table-of-contents
 
 Generates a table of contents for your HTML document based on the headings 
 present.


### PR DESCRIPTION
The missing space was causing the Header not to render on GitHub, correct MarkDown syntax is `# Heading 1`